### PR TITLE
nmfs-ost migration: README link fixes

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -25,7 +25,8 @@ AGEPRO (Age Structured Projection Model).
 >
 > **If you using AGEPRO for production, please use:**
 > <!-- Leave links to PIFSC until repos are migrated to nmfs-ost -->
-> - [Jon Brodziak's original AGEPRO program (source code)](https://github.com/PIFSCstockassessments/AGEPRO)
+>
+> - [Jon Brodziak's original AGEPRO program (source code)](https://github.com/PIFSCstockassessments/AGEPRO)  
 > - [GUI interface for AGEPRO (installer & source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
 
 ## Note

--- a/README.Rmd
+++ b/README.Rmd
@@ -21,6 +21,13 @@ knitr::opts_chunk$set(
 ageproR is a R-package designed to handle input data to and from Jon Brodizak's 
 AGEPRO (Age Structured Projection Model). 
 
+> [!IMPORTANT]
+>
+> **If you using AGEPRO for production, please use:**
+> <!-- Leave links to PIFSC until repos are migrated to nmfs-ost -->
+> - [Jon Brodziak's original AGEPRO program (source code)](https://github.com/PIFSCstockassessments/AGEPRO)
+> - [GUI interface for AGEPRO (installer & source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
+
 ## Note
 
 **ageproR** is still in development. These features will be implemented in future updates. 
@@ -33,26 +40,20 @@ AGEPRO (Age Structured Projection Model).
 
 Importing Stock Synthesis report data as AGEPRO input data is being developed as a separate R-package: ss3agepro
 
-
-**If you using AGEPRO for production, please use:**
-
-- [Jon Brodziak's original AGEPRO program (source code)](https://github.com/PIFSCstockassessments/AGEPRO)
-- [GUI interface for AGEPRO (installer & source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
-
 ## Installation
 
 You can install the development version of ageproR from 
-[PIFSCstockassessments GitHub Repository](https://github.com/PIFSCstockassessments/ageproR) 
+[NOAA Fisheries OST Repository](https://github.com/nmfs-ost/ageproR) 
 with:
 
 ```{r, eval = FALSE}
 # via `pak`
 install.packages("pak")
-pak::pkg_install("PIFSCstockassessments/ageproR")
+pak::pkg_install("nmfs-ost/ageproR")
 
-# alternative\legacy method
+# alternative method
 install.packages("remotes")
-remotes::install_github("PIFSCstockassessments/ageproR")
+remotes::install_github("nmfs-ost/ageproR")
 ```
 
 ## AGEPRO input file format

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Brodizak’s AGEPRO (Age Structured Projection Model).
 > \[!IMPORTANT\]
 >
 > **If you using AGEPRO for production, please use:**
-> <!-- Leave links to PIFSC until repos are migrated to nmfs-ost --> -
-> [Jon Brodziak’s original AGEPRO program (source
-> code)](https://github.com/PIFSCstockassessments/AGEPRO) - [GUI
-> interface for AGEPRO (installer &
-> source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
+> <!-- Leave links to PIFSC until repos are migrated to nmfs-ost -->
+>
+> - [Jon Brodziak’s original AGEPRO program (source
+>   code)](https://github.com/PIFSCstockassessments/AGEPRO)  
+> - [GUI interface for AGEPRO (installer &
+>   source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
 
 ## Note
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@
 ageproR is a R-package designed to handle input data to and from Jon
 Brodizak’s AGEPRO (Age Structured Projection Model).
 
+> \[!IMPORTANT\]
+>
+> **If you using AGEPRO for production, please use:**
+> <!-- Leave links to PIFSC until repos are migrated to nmfs-ost --> -
+> [Jon Brodziak’s original AGEPRO program (source
+> code)](https://github.com/PIFSCstockassessments/AGEPRO) - [GUI
+> interface for AGEPRO (installer &
+> source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
+
 ## Note
 
 **ageproR** is still in development. These features will be implemented
@@ -26,27 +35,19 @@ in future updates.
 Importing Stock Synthesis report data as AGEPRO input data is being
 developed as a separate R-package: ss3agepro
 
-**If you using AGEPRO for production, please use:**
-
-- [Jon Brodziak’s original AGEPRO program (source
-  code)](https://github.com/PIFSCstockassessments/AGEPRO)
-- [GUI interface for AGEPRO (installer &
-  source)](https://github.com/PIFSCstockassessments/AGEPRO-GUI)
-
 ## Installation
 
-You can install the development version of ageproR from
-[PIFSCstockassessments GitHub
-Repository](https://github.com/PIFSCstockassessments/ageproR) with:
+You can install the development version of ageproR from [NOAA Fisheries
+OST Repository](https://github.com/nmfs-ost/ageproR) with:
 
 ``` r
 # via `pak`
 install.packages("pak")
-pak::pkg_install("PIFSCstockassessments/ageproR")
+pak::pkg_install("nmfs-ost/ageproR")
 
-# alternative\legacy method
+# alternative method
 install.packages("remotes")
-remotes::install_github("PIFSCstockassessments/ageproR")
+remotes::install_github("nmfs-ost/ageproR")
 ```
 
 ## AGEPRO input file format


### PR DESCRIPTION
Fixes links in README
resolves #81 


Note: Jon Brodziak's AGEPRO source code, and AGEPRO-GUI is currently linked to PIFSCstockassessments, and is pending migration.


